### PR TITLE
Add payment form data to the custom plan name

### DIFF
--- a/src/services/Checkout.php
+++ b/src/services/Checkout.php
@@ -290,7 +290,7 @@ class Checkout extends Component
                     $trialPeriodDays = $finalTrialPeriodDays;
                 }
 
-                $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+                $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
             }
         }
 
@@ -321,7 +321,7 @@ class Checkout extends Component
                 "currency" => $paymentForm->currency
             ]);
 
-            $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+            $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
         }
 
         $planItem =  [

--- a/src/services/Orders.php
+++ b/src/services/Orders.php
@@ -1242,7 +1242,7 @@ class Orders extends Component
         }
 
         //Create new plan for this customer:
-        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
 
         // Add the plan to the customer
         $subscriptionSettings = [
@@ -1303,7 +1303,7 @@ class Orders extends Component
             $customPlan->trialPeriodDays = $trialPeriodDays;
         }
 
-        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
 
         // Add the plan to the customer
         $subscriptionSettings = [

--- a/src/services/Plans.php
+++ b/src/services/Plans.php
@@ -9,6 +9,7 @@
 namespace enupal\stripe\services;
 
 use Craft;
+use enupal\stripe\elements\PaymentForm;
 use enupal\stripe\models\CustomPlan;
 use Stripe\Price;
 use yii\base\Component;
@@ -245,14 +246,20 @@ class Plans extends Component
      * @param CustomPlan $customPlan
      * @return Plan
      */
-    public function createCustomPlan(CustomPlan $customPlan)
+    public function createCustomPlan(CustomPlan $customPlan, PaymentForm $paymentForm)
     {
         $currentTime = time();
         $planName = strval($currentTime);
+	    $paymentFormName = $paymentForm->name;
+	    $paymentFormHandle = $paymentForm->handle;
         //Create new plan for this customer:
 
         $settings = StripePlugin::$app->settings->getSettings();
-        $productName = Craft::$app->getView()->renderObjectTemplate($settings->customPlanName, ['planId' => $planName]);
+        $productName = Craft::$app->getView()->renderObjectTemplate($settings->customPlanName, [
+	        'planId' => $planName,
+	        'paymentFormName' => $paymentFormName,
+	        'paymentFormHandle' => $paymentFormHandle
+        ]);
 
         $params = [
             "amount" => $customPlan->amountInCents,


### PR DESCRIPTION
Hello devs,
I got a client with a Craft installation using the Stripe plugin that asked if it was possible to add to the custom plan name - during the checkout process - some of the payment form data (name, handle) because if the stripe checkout is being used (eg. when the SCA is enabled) then the name of the custom plan can only contain the plan id as a dynamic value. If the payment form name could be used too, that would lower the friction caused by seeing a random number (from the user perspective) and will help the client to identify the form that originated the transaction (see the two screenshots as an example).
I've created the PR that will only add the paymentform object to the createCustomPlan method and allows the customer to add the placeholder on the settings page, if needed.

![image](https://github.com/enupal/stripe/assets/128366984/430d341a-4b97-4ac5-816a-2853ae0e0127)
![image](https://github.com/enupal/stripe/assets/128366984/ba1cc21c-1742-4000-8982-dbe7a1669253)
