### PR TITLE
Josdigital changes

### DIFF
--- a/src/services/Checkout.php
+++ b/src/services/Checkout.php
@@ -290,7 +290,7 @@ class Checkout extends Component
                     $trialPeriodDays = $finalTrialPeriodDays;
                 }
 
-                $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+                $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
             }
         }
 
@@ -321,7 +321,7 @@ class Checkout extends Component
                 "currency" => $paymentForm->currency
             ]);
 
-            $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+            $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
         }
 
         $planItem =  [

--- a/src/services/Orders.php
+++ b/src/services/Orders.php
@@ -1242,7 +1242,7 @@ class Orders extends Component
         }
 
         //Create new plan for this customer:
-        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
 
         // Add the plan to the customer
         $subscriptionSettings = [
@@ -1303,7 +1303,7 @@ class Orders extends Component
             $customPlan->trialPeriodDays = $trialPeriodDays;
         }
 
-        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan);
+        $plan = StripePlugin::$app->plans->createCustomPlan($customPlan, $paymentForm);
 
         // Add the plan to the customer
         $subscriptionSettings = [

--- a/src/services/Plans.php
+++ b/src/services/Plans.php
@@ -9,6 +9,7 @@
 namespace enupal\stripe\services;
 
 use Craft;
+use enupal\stripe\elements\PaymentForm;
 use enupal\stripe\models\CustomPlan;
 use Stripe\Price;
 use yii\base\Component;
@@ -245,14 +246,17 @@ class Plans extends Component
      * @param CustomPlan $customPlan
      * @return Plan
      */
-    public function createCustomPlan(CustomPlan $customPlan)
+    public function createCustomPlan(CustomPlan $customPlan, PaymentForm $paymentForm)
     {
         $currentTime = time();
         $planName = strval($currentTime);
         //Create new plan for this customer:
 
         $settings = StripePlugin::$app->settings->getSettings();
-        $productName = Craft::$app->getView()->renderObjectTemplate($settings->customPlanName, ['planId' => $planName]);
+        $productName = Craft::$app->getView()->renderObjectTemplate($settings->customPlanName, [
+            'planId' => $planName,
+            'paymentForm' => $paymentForm
+        ]);
 
         $params = [
             "amount" => $customPlan->amountInCents,

--- a/src/services/Settings.php
+++ b/src/services/Settings.php
@@ -65,6 +65,7 @@ class Settings extends Component
         $settings->testClientId = $configSettings['testClientId'] ?? $settings->testClientId;
         $settings->testWebhookSigningSecret = $configSettings['testWebhookSigningSecret'] ?? $settings->testWebhookSigningSecret;
         $settings->testMode = $configSettings['testMode'] ?? $settings->testMode;
+        $settings->useSca = $configSettings['useSca'] ?? $settings->useSca;
 
         return $settings;
     }

--- a/src/services/Settings.php
+++ b/src/services/Settings.php
@@ -66,6 +66,7 @@ class Settings extends Component
         $settings->testWebhookSigningSecret = $configSettings['testWebhookSigningSecret'] ?? $settings->testWebhookSigningSecret;
         $settings->testMode = $configSettings['testMode'] ?? $settings->testMode;
         $settings->useSca = $configSettings['useSca'] ?? $settings->useSca;
+        $settings->capture = $configSettings['capture'] ?? $settings->capture;
 
         return $settings;
     }


### PR DESCRIPTION
- Adds support for `useSca` and `capture` override via [config settings](https://docs.enupal.com/stripe-payments/getting-started/saving-your-stripe-api-keys.html#saving-the-stripe-api-keys-via-config-file)
- Adds support for the `paymentForm` object to be used on the `Custom Plan Name` setting, e.g: `Custom Plan - {planId} - {paymentForm.handle}`